### PR TITLE
Add ability to set default tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The latest version of Anemometer can be found on the [Releases](https://github.c
 ```yaml
 statsd:
   address: 127.0.0.1:8125
+  tags:
+    - environment:production
 monitors:
   - name: airflow-dag-disabled
     database:
@@ -65,6 +67,7 @@ monitors:
 ### `statsd`
 This is where you tell Anemometer where to send StatsD metrics
 - `address` - The address:port on which StatsD is listening (usually `127.0.0.1:8125`)
+- `tags` - Default tags to send with every metric, optional
 
 ### `monitors`
 This is where you tell Anemometer about the monitor(s) configuration

--- a/pkg/anemometer/config/config.go
+++ b/pkg/anemometer/config/config.go
@@ -35,7 +35,8 @@ type Config struct {
 
 // StatsdConfig holds statsd specific configuration
 type StatsdConfig struct {
-	Address string `mapstructure:"address"`
+	Address string   `mapstructure:"address"`
+	Tags    []string `mapstructure:"tags"`
 }
 
 // DatabaseConfig holds database connection specific configuration

--- a/pkg/anemometer/monitor/monitor.go
+++ b/pkg/anemometer/monitor/monitor.go
@@ -31,7 +31,10 @@ func New(statsdConfig config.StatsdConfig, monitorConfig config.MonitorConfig) (
 		return nil, err
 	}
 
-	statsdClient, err := createStatsdClient(statsdConfig.Address)
+	statsdClient, err := createStatsdClient(
+		statsdConfig.Address,
+		statsdConfig.Tags,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -62,8 +65,11 @@ func createDBConn(dbType string, dbURI string) (*sql.DB, error) {
 	return conn, nil
 }
 
-func createStatsdClient(address string) (*statsd.Client, error) {
-	client, err := statsd.New(address)
+func createStatsdClient(address string, tags []string) (*statsd.Client, error) {
+	client, err := statsd.New(
+		address,
+		statsd.WithTags(tags),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It is sometimes desirable to always push some tags along with your DataDog metrics.  For instance, if you have both a production and development environment.

This PR adds the optional ability to have default tags sent with every metric.