### PR TITLE
Improve logging output, add debug

### DIFF
--- a/cmd/anemometer/cli/start.go
+++ b/cmd/anemometer/cli/start.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	configPath string
+	debug      bool
 )
 
 var startCmd = &cobra.Command{
@@ -27,6 +28,12 @@ func init() {
 		"c",
 		"/etc/anemometer.yml",
 		"the full path to the yaml config file, default: /etc/anemometer.yml")
+	startCmd.Flags().BoolVarP(
+		&debug,
+		"debug",
+		"d",
+		false,
+		"enable debugging output in the logs, default: false")
 	rootCmd.AddCommand(startCmd)
 }
 
@@ -47,7 +54,7 @@ func start() {
 		if err != nil {
 			log.Panicf("ERROR: Failed to start monitor '%v': %v", mtConfig.Name, err)
 		}
-		go mt.Start()
+		go mt.Start(debug)
 	}
 	// Block until something kills the process
 	<-exit


### PR DESCRIPTION
Logs will now indicate which monitor is sleeping:
```
2020/05/28 09:26:32 INFO: [my-first-monitor] Sleeping for 300 seconds
2020/05/28 09:26:32 INFO: [my-second-monitor] Sleeping for 300 seconds
2020/05/28 09:26:32 INFO: [my-other-monitor] Sleeping for 300 seconds
```

When debug is enabled (`anemometer start --debug`), you'll see the actual metrics in the logs:
```
2020/05/28 09:26:32 DEBUG: [my-first-monitor] Publishing metric - Name: my.first.metric, Value: 1, Tags: [my:tag, other:tag]
2020/05/28 09:26:32 INFO: [my-first-monitor] Sleeping for 300 seconds
2020/05/28 09:26:32 DEBUG: [my-second-monitor] Publishing metric - Name: my.second.metric, Value: 1.9999, Tags: [my:tag, other:tag]
2020/05/28 09:26:32 INFO: [my-second-monitor] Sleeping for 300 seconds
```

Closes #2 