### PR TITLE
Remove golint - deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ env:
 go:
   - 1.21.x
 
-before_script:
-  - GO111MODULE=off go get -u golang.org/x/lint/golint
-
 script:
   - make
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TAG?=""
 
 # Run all tests
 .PHONY: test
-test: fmt lint vet test-unit go-mod-tidy
+test: fmt vet test-unit go-mod-tidy
 
 # Run unit tests
 .PHONY: test-unit
@@ -21,11 +21,6 @@ go-mod-tidy:
 .PHONY: fmt
 fmt:
 	test -z "$(shell gofmt -l .)"
-
-# Run linter
-.PHONY: lint
-lint:
-	golint -set_exit_status ./...
 
 # Run vet
 .PHONY: vet


### PR DESCRIPTION
[INF-5707](https://simplifi.atlassian.net/browse/INF-5707)
---

`golint` has been deprecated, they advise you to use `go vet` instead - which we're already doing.

[INF-5707]: https://simplifi.atlassian.net/browse/INF-5707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ