### PR TITLE
Add Support for More Datadog Metric Types

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -1,0 +1,15 @@
+statsd:
+  address: 127.0.0.1:8125
+  tags:
+    - environment:prod
+monitors:
+  # Example SQLite monitor (great for local development and testing!)
+  - name: test-metric
+    database:
+      type: sqlite3
+      uri: ':memory:'
+    sleep_duration: 1
+    metric: test.metric
+    metric_type: gauge
+    sql: >
+      SELECT 1 AS metric;

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,10 @@ toolchain go1.24.2
 require (
 	github.com/DataDog/datadog-go v4.8.3+incompatible
 	github.com/lib/pq v1.10.9
+	github.com/mattn/go-sqlite3 v1.14.32
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	github.com/vertica/vertica-sql-go v1.3.3
 	github.com/viant/bigquery v0.5.1
 )
@@ -58,6 +59,7 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/viant/afs v1.25.1-0.20231110184132-877ed98abca1 // indirect
 	github.com/viant/parsly v0.0.0-20220907184615-a27c125714a1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -912,6 +912,8 @@ github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
+github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
@@ -1018,8 +1020,9 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=

--- a/pkg/anemometer/config/config_test.go
+++ b/pkg/anemometer/config/config_test.go
@@ -44,4 +44,124 @@ monitors:
 	assert.Equal(t, 300, cfg.Monitors[0].SleepDuration)
 	assert.Equal(t, "my.test.metric", cfg.Monitors[0].Metric)
 	assert.Equal(t, "SELECT 'foo' AS dag_id, 100 AS metric", cfg.Monitors[0].SQL)
+	// Should default to gauge when no metric_type specified
+	assert.Equal(t, "gauge", cfg.Monitors[0].MetricType)
+}
+
+func TestMetricTypes(t *testing.T) {
+	tests := []struct {
+		name          string
+		configYAML    string
+		expectedTypes []string
+		description   string
+	}{
+		{
+			name: "default_gauge",
+			configYAML: `
+statsd:
+  address: 127.0.0.1:8125
+monitors:
+  - name: test-default
+    database:
+      type: postgres
+      uri: postgresql://test
+    sleep_duration: 300
+    metric: test.metric
+    sql: SELECT 1 as metric`,
+			expectedTypes: []string{"gauge"},
+			description:   "Missing metric_type should default to gauge",
+		},
+		{
+			name: "case_normalization",
+			configYAML: `
+statsd:
+  address: 127.0.0.1:8125
+monitors:
+  - name: test-upper
+    database:
+      type: postgres
+      uri: postgresql://test
+    sleep_duration: 300
+    metric: test.metric
+    metric_type: COUNT
+    sql: SELECT 1 as metric
+  - name: test-mixed
+    database:
+      type: postgres
+      uri: postgresql://test
+    sleep_duration: 300
+    metric: test.metric
+    metric_type: Histogram
+    sql: SELECT 1 as metric`,
+			expectedTypes: []string{"count", "histogram"},
+			description:   "Case should be normalized to lowercase",
+		},
+		{
+			name: "all_valid_types",
+			configYAML: `
+statsd:
+  address: 127.0.0.1:8125
+monitors:
+  - name: test-gauge
+    database:
+      type: postgres
+      uri: postgresql://test
+    sleep_duration: 300
+    metric: test.gauge
+    metric_type: gauge
+    sql: SELECT 1 as metric
+  - name: test-count
+    database:
+      type: postgres
+      uri: postgresql://test
+    sleep_duration: 300
+    metric: test.count
+    metric_type: count
+    sql: SELECT 1 as metric
+  - name: test-histogram
+    database:
+      type: postgres
+      uri: postgresql://test
+    sleep_duration: 300
+    metric: test.histogram
+    metric_type: histogram
+    sql: SELECT 1 as metric
+  - name: test-distribution
+    database:
+      type: postgres
+      uri: postgresql://test
+    sleep_duration: 300
+    metric: test.distribution
+    metric_type: distribution
+    sql: SELECT 1 as metric`,
+			expectedTypes: []string{"gauge", "count", "histogram", "distribution"},
+			description:   "All valid metric types should be preserved",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp config file
+			tmpfile, err := ioutil.TempFile("", "config")
+			assert.NoError(t, err)
+			defer os.Remove(tmpfile.Name())
+			defer tmpfile.Close()
+
+			_, err = tmpfile.Write([]byte(tt.configYAML))
+			assert.NoError(t, err)
+
+			// Read and parse config
+			cfg, err := Read(tmpfile.Name())
+			assert.NoError(t, err)
+
+			// Check number of monitors
+			assert.Equal(t, len(tt.expectedTypes), len(cfg.Monitors))
+
+			// Check each monitor's metric type
+			for i, expected := range tt.expectedTypes {
+				assert.Equal(t, expected, cfg.Monitors[i].MetricType,
+					"Monitor %d: expected type '%s', got '%s'", i, expected, cfg.Monitors[i].MetricType)
+			}
+		})
+	}
 }

--- a/pkg/anemometer/monitor/monitor_test.go
+++ b/pkg/anemometer/monitor/monitor_test.go
@@ -2,10 +2,100 @@ package monitor
 
 import (
 	"testing"
+	"time"
 
+	"github.com/DataDog/datadog-go/statsd"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/simplifi/anemometer/pkg/anemometer/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
+
+// MockStatsDClient is a testify mock implementation of statsd.ClientInterface
+type MockStatsDClient struct {
+	mock.Mock
+}
+
+func (m *MockStatsDClient) Gauge(name string, value float64, tags []string, rate float64) error {
+	args := m.Called(name, value, tags, rate)
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) Count(name string, value int64, tags []string, rate float64) error {
+	args := m.Called(name, value, tags, rate)
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) Histogram(name string, value float64, tags []string, rate float64) error {
+	args := m.Called(name, value, tags, rate)
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) Distribution(name string, value float64, tags []string, rate float64) error {
+	args := m.Called(name, value, tags, rate)
+	return args.Error(0)
+}
+
+// Minimal implementations for unused methods to satisfy the interface
+func (m *MockStatsDClient) Decr(name string, tags []string, rate float64) error {
+	args := m.Called(name, tags, rate)
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) Incr(name string, tags []string, rate float64) error {
+	args := m.Called(name, tags, rate)
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) Set(name string, value string, tags []string, rate float64) error {
+	args := m.Called(name, value, tags, rate)
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) Timing(name string, value time.Duration, tags []string, rate float64) error {
+	args := m.Called(name, value, tags, rate)
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) TimeInMilliseconds(name string, value float64, tags []string, rate float64) error {
+	args := m.Called(name, value, tags, rate)
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) Event(e *statsd.Event) error {
+	args := m.Called(e)
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) SimpleEvent(title, text string) error {
+	args := m.Called(title, text)
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) ServiceCheck(sc *statsd.ServiceCheck) error {
+	args := m.Called(sc)
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) SimpleServiceCheck(name string, status statsd.ServiceCheckStatus) error {
+	args := m.Called(name, status)
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) Flush() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStatsDClient) SetWriteTimeout(d time.Duration) error {
+	args := m.Called(d)
+	return args.Error(0)
+}
 
 func TestMonitorNew(t *testing.T) {
 	testStatsdConfig := config.StatsdConfig{
@@ -13,8 +103,8 @@ func TestMonitorNew(t *testing.T) {
 	}
 
 	testDatabaseConfig := config.DatabaseConfig{
-		Type: "postgres",
-		URI:  "postgresql://user:password@localhost:5432/database",
+		Type: "sqlite3",
+		URI:  ":memory:",
 	}
 
 	testMonitorCfg := config.MonitorConfig{
@@ -22,11 +112,297 @@ func TestMonitorNew(t *testing.T) {
 		DatabaseConfig: testDatabaseConfig,
 		SleepDuration:  100,
 		Metric:         "my.test.metric",
-		SQL:            "select 'tag' AS my_tag, 100 AS metric",
+		SQL:            "SELECT 100 AS metric, 'tag' AS my_tag",
 	}
 
 	monitor, err := New(testStatsdConfig, testMonitorCfg)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, monitor)
+}
+
+// Comprehensive integration test using SQLite + Mock StatsD
+func TestMonitorIntegration(t *testing.T) {
+	// Test different metric types
+	testCases := []struct {
+		name       string
+		metricType string
+		sqlQuery   string
+		setupMock  func(*MockStatsDClient)
+	}{
+		{
+			name:       "count-metric",
+			metricType: "count",
+			sqlQuery:   "SELECT 42 AS metric, 'us-east' AS region",
+			setupMock: func(m *MockStatsDClient) {
+				m.On("Count", "app.test.count-metric", int64(42), []string{"region:us-east"}, float64(1)).Return(nil)
+			},
+		},
+		{
+			name:       "gauge-metric",
+			metricType: "gauge",
+			sqlQuery:   "SELECT 85.5 AS metric, 'premium' AS tier",
+			setupMock: func(m *MockStatsDClient) {
+				m.On("Gauge", "app.test.gauge-metric", 85.5, []string{"tier:premium"}, float64(1)).Return(nil)
+			},
+		},
+		{
+			name:       "histogram-metric",
+			metricType: "histogram",
+			sqlQuery:   "SELECT 95.0 AS metric, 'all' AS segment",
+			setupMock: func(m *MockStatsDClient) {
+				m.On("Histogram", "app.test.histogram-metric", 95.0, []string{"segment:all"}, float64(1)).Return(nil)
+			},
+		},
+		{
+			name:       "distribution-metric",
+			metricType: "distribution",
+			sqlQuery:   "SELECT 75.25 AS metric, 'baseline' AS category",
+			setupMock: func(m *MockStatsDClient) {
+				m.On("Distribution", "app.test.distribution-metric", 75.25, []string{"category:baseline"}, float64(1)).Return(nil)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStatsD := &MockStatsDClient{}
+			tc.setupMock(mockStatsD)
+
+			databaseConn, err := createDBConn("sqlite3", ":memory:")
+			assert.NoError(t, err)
+			defer databaseConn.Close()
+
+			monitor := &Monitor{
+				databaseConn:  databaseConn,
+				statsdClient:  mockStatsD,
+				name:          tc.name,
+				sleepDuration: 100,
+				metric:        "app.test." + tc.name,
+				metricType:    tc.metricType,
+				sql:           tc.sqlQuery,
+			}
+
+			// Execute query and send metric (simulates one monitor cycle)
+			rows, err := monitor.databaseConn.Query(monitor.sql)
+			assert.NoError(t, err)
+			defer rows.Close()
+
+			cols, _ := rows.Columns()
+
+			for rows.Next() {
+				rowMap, err := rowsToMap(cols, rows)
+				assert.NoError(t, err)
+
+				tags := getTags(rowMap)
+				err = monitor.sendMetric(rowMap, tags, false)
+				assert.NoError(t, err)
+			}
+
+			mockStatsD.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetMetricFloat64(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected float64
+		hasError bool
+	}{
+		{
+			name:     "int_value",
+			input:    map[string]interface{}{"metric": 42},
+			expected: 42.0,
+			hasError: false,
+		},
+		{
+			name:     "int64_value",
+			input:    map[string]interface{}{"metric": int64(123456789)},
+			expected: 123456789.0,
+			hasError: false,
+		},
+		{
+			name:     "float64_value",
+			input:    map[string]interface{}{"metric": 3.14159},
+			expected: 3.14159,
+			hasError: false,
+		},
+		{
+			name:     "float32_value",
+			input:    map[string]interface{}{"metric": float32(2.718)},
+			expected: float64(float32(2.718)), // Account for float32 precision
+			hasError: false,
+		},
+		{
+			name:     "bool_true",
+			input:    map[string]interface{}{"metric": true},
+			expected: 1.0,
+			hasError: false,
+		},
+		{
+			name:     "bool_false",
+			input:    map[string]interface{}{"metric": false},
+			expected: 0.0,
+			hasError: false,
+		},
+		{
+			name:     "missing_metric_column",
+			input:    map[string]interface{}{"other_column": 42},
+			expected: 0.0,
+			hasError: true,
+		},
+		{
+			name:     "string_value_should_error",
+			input:    map[string]interface{}{"metric": "not_a_number"},
+			expected: 0.0,
+			hasError: true,
+		},
+		{
+			name:     "negative_int",
+			input:    map[string]interface{}{"metric": -42},
+			expected: -42.0,
+			hasError: false,
+		},
+		{
+			name:     "zero_value",
+			input:    map[string]interface{}{"metric": 0},
+			expected: 0.0,
+			hasError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := getMetricFloat64(tt.input)
+
+			if tt.hasError {
+				assert.Error(t, err, "Expected error but got none")
+				return
+			}
+
+			assert.NoError(t, err, "Unexpected error: %v", err)
+			assert.Equal(t, tt.expected, result, "Expected %f, got %f", tt.expected, result)
+		})
+	}
+}
+
+func TestGetTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected []string
+	}{
+		{
+			name: "simple_tags",
+			input: map[string]interface{}{
+				"metric":      42,
+				"environment": "production",
+				"service":     "web",
+			},
+			expected: []string{"environment:production", "service:web"},
+		},
+		{
+			name: "mixed_types",
+			input: map[string]interface{}{
+				"metric":  3.14,
+				"count":   123,
+				"enabled": true,
+				"region":  "us-east-1",
+			},
+			expected: []string{"count:123", "enabled:true", "region:us-east-1"},
+		},
+		{
+			name: "only_metric_column",
+			input: map[string]interface{}{
+				"metric": 1,
+			},
+			expected: []string{},
+		},
+		{
+			name:     "empty_map",
+			input:    map[string]interface{}{},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getTags(tt.input)
+
+			assert.Equal(t, len(tt.expected), len(result), "Expected %d tags, got %d", len(tt.expected), len(result))
+
+			// Check that all expected tags are present (order doesn't matter)
+			expectedMap := make(map[string]bool)
+			for _, tag := range tt.expected {
+				expectedMap[tag] = true
+			}
+
+			for _, tag := range result {
+				assert.True(t, expectedMap[tag], "Unexpected tag: %s", tag)
+				delete(expectedMap, tag)
+			}
+
+			assert.Equal(t, 0, len(expectedMap), "Missing expected tags: %v", expectedMap)
+		})
+	}
+}
+
+func TestMetricTypeHandling(t *testing.T) {
+	tests := []struct {
+		name       string
+		metricType string
+		expectErr  bool
+	}{
+		{name: "gauge_type", metricType: "gauge", expectErr: false},
+		{name: "count_type", metricType: "count", expectErr: false},
+		{name: "histogram_type", metricType: "histogram", expectErr: false},
+		{name: "distribution_type", metricType: "distribution", expectErr: false},
+		{name: "unknown_type", metricType: "unknown", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock StatsD client
+			mockStatsD := &MockStatsDClient{}
+
+			// Set up mock expectations for valid metric types
+			if !tt.expectErr {
+				switch tt.metricType {
+				case "gauge":
+					mockStatsD.On("Gauge", "test.metric", 42.0, []string{"environment:test"}, float64(1)).Return(nil)
+				case "count":
+					mockStatsD.On("Count", "test.metric", int64(42), []string{"environment:test"}, float64(1)).Return(nil)
+				case "histogram":
+					mockStatsD.On("Histogram", "test.metric", 42.0, []string{"environment:test"}, float64(1)).Return(nil)
+				case "distribution":
+					mockStatsD.On("Distribution", "test.metric", 42.0, []string{"environment:test"}, float64(1)).Return(nil)
+				}
+			}
+
+			monitor := &Monitor{
+				name:         "test",
+				metric:       "test.metric",
+				metricType:   tt.metricType,
+				statsdClient: mockStatsD,
+			}
+
+			rowMap := map[string]interface{}{
+				"metric":      42.0,
+				"environment": "test",
+			}
+			tags := []string{"environment:test"}
+
+			err := monitor.sendMetric(rowMap, tags, false)
+
+			if tt.expectErr {
+				assert.Error(t, err, "Expected error for unknown metric type")
+				assert.Contains(t, err.Error(), "unknown metric type", "Error should mention unknown metric type")
+			} else {
+				assert.NoError(t, err, "Should not error for known metric type")
+				mockStatsD.AssertExpectations(t)
+			}
+		})
+	}
 }


### PR DESCRIPTION
# Add Support for More Datadog Metric Types

This PR extends Anemometer's monitoring capabilities by adding support for three Datadog metric types: `count`, `histogram`, `distribution`, and `gauge` (existing default).

## What's Changed

### New Metric Types
- **Count**: Track discrete events (errors, requests, etc.)
  - Automatically converts values to integers
  - StatsD format: `metric_name:value|c|#tags`
- **Histogram**: Statistical distribution per host (latency, file sizes)
  - StatsD format: `metric_name:value|h|#tags`
- **Distribution**: Statistical distribution across infrastructure
  - StatsD format: `metric_name:value|d|#tags`

### Configuration Enhancement
```yaml
monitors:
  - name: failed-tasks-count
    metric_type: count  # New optional field
    # ... rest of config
```

### Backwards Compatibility
- `metric_type` field is optional and defaults to `gauge`
- Existing configurations continue to work without changes
- Case-insensitive metric type specification (COUNT, count, Count all work)

### Additional Improvements
- **SQLite support** for local development and testing
- **Comprehensive test suite** covering all metric types and edge cases
- **Enhanced documentation** with practical examples for each metric type
- **Improved error handling** and validation

## Testing
- Added 300+ lines of test coverage
- Tests for metric type validation, case normalization, and backwards compatibility
- SQLite integration tests for development workflows

## Migration Guide
No breaking changes - existing configurations work as-is. To use new metric types, simply add `metric_type: <type>` to your monitor configuration.