### PR TITLE
Fix certs issues in Docker for BQ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
 FROM ubuntu:24.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 ENTRYPOINT ["/anemometer"]
 COPY anemometer /


### PR DESCRIPTION
[INT-11981](https://simplifi.atlassian.net/browse/INT-11981)
---
Found an issue where BQ queries failed to run because the certs were not installed.

[INT-11981]: https://simplifi.atlassian.net/browse/INT-11981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ