### PR TITLE
Add DogStatsD event support to monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 <img src="assets/anemometer.png" width="100">
 
-Anemometer is a tool for running SQL queries and pushing results as metrics to
-Datadog
+Anemometer is a tool for running SQL queries and pushing results as metrics and
+optional events to Datadog
 
 ## Why "Anemometer"
 
@@ -93,6 +93,46 @@ monitors:
       FROM   task_instance WHERE  state = 'failed'
         AND  end_date > NOW() - INTERVAL '1 hour'
       GROUP BY dag_id
+
+  # Event monitor - emit the configured metric plus one event for each returned row
+  - name: postgres-long-running-queries
+    database:
+      type: postgres
+      uri: postgresql://username:password@localhost:5432/database?sslmode=disable
+    sleep_duration: 1800
+    metric: postgres.long_running_query
+    metric_type: gauge
+    event:
+      enabled: true
+      title_column: event_title
+      text_column: event_text
+      alert_type: warning
+      priority: normal
+      source_type_name: anemometer
+      aggregation_key_column: event_aggregation_key
+      tags:
+        - alert_type:long_running_query
+      tag_columns:
+        - database_name
+        - duration_bucket
+    sql: >
+      SELECT 1 AS metric,
+             datname AS database_name,
+             CASE
+               WHEN now() - query_start > interval '6 hours' THEN '6h_plus'
+               WHEN now() - query_start > interval '4 hours' THEN '4h_plus'
+               ELSE '2h_plus'
+             END AS duration_bucket,
+             'Long running Postgres query' AS event_title,
+             'Database: ' || datname || E'\n' ||
+             'User: ' || usename || E'\n' ||
+             'PID: ' || pid || E'\n' ||
+             'Runtime: ' || (now() - query_start)::text || E'\n\n' ||
+             query AS event_text,
+             'postgres-long-running-query:' || datname || ':' || pid AS event_aggregation_key
+      FROM pg_stat_activity
+      WHERE state = 'active'
+        AND now() - query_start > interval '2 hours'
 ```
 
 ### `statsd`
@@ -101,7 +141,7 @@ This is where you tell Anemometer where to send StatsD metrics
 
 - `address` - The address:port on which StatsD is listening (usually
   `127.0.0.1:8125`)
-- `tags` - Default tags to send with every metric, optional
+- `tags` - Default tags to send with every metric and event, optional
 
 ### `monitors`
 
@@ -116,6 +156,8 @@ This is where you tell Anemometer about the monitor(s) configuration
 - `metric` - The name of the metric to be sent to StatsD
 - `metric_type` - The type of metric to send to Datadog (optional, defaults to
   `gauge`)
+- `event` - Optional Datadog event configuration. When enabled, one event is sent
+  for each row returned by the SQL query.
 - `sql` - The SQL query to execute when populating the metric's values/tags (see
   [SQL Query Structure](#sql-query-structure))
 
@@ -128,6 +170,9 @@ Anemometer makes the following assumptions about the results of your query:
 - An optional column named `timestamp` can be included to explicitly provide a timestamp for the metrics (only supported for `gauge` and `count` types)
 - All other columns will be aggregated into tags and sent to StatsD
 - The tags will take the form of `column_name:value`
+- Event payload columns such as `event_title`, `event_text`,
+  `event_aggregation_key`, and configured title/text/aggregation/hostname
+  columns are not used as metric tags by default.
 
 ## Metric Types
 
@@ -170,6 +215,45 @@ type using the `metric_type` configuration option:
 **Note**: The `metric_type` field is optional and defaults to `gauge` for
 backwards compatibility. Existing configurations will continue to work without
 any changes.
+
+## Event Support
+
+Anemometer can also send Datadog events through DogStatsD. This is useful for
+alert conditions where the SQL query itself controls whether anything should be
+emitted. For example, a long-running-query monitor can return only sessions that
+have been active for more than two hours. If the query returns no rows, no events
+are sent. If the query returns three rows, three events are sent.
+
+Events are sent in addition to the configured metric. Event-enabled monitors
+still need a `metric` setting and a SQL `metric` column.
+
+The monitor's `sleep_duration` controls how often Anemometer re-checks the query
+and therefore how often a still-true condition can re-notify through a Datadog
+event monitor.
+
+### Event configuration
+
+- `enabled` - Set to `true` to send one event for each returned SQL row
+- `title` - Static event title. Used when `title_column` is not configured
+- `title_column` - SQL result column containing the event title
+- `text` - Static event body. Used when `text_column` is not configured
+- `text_column` - SQL result column containing the event body
+- `alert_type` - Event type: `info`, `warning`, `error`, or `success` (defaults
+  to `info`)
+- `priority` - Event priority: `normal` or `low` (defaults to `normal`)
+- `source_type_name` - Event source type (defaults to `anemometer`)
+- `aggregation_key` - Static key used by Datadog to group related events
+- `aggregation_key_column` - SQL result column containing the aggregation key
+- `hostname` - Static hostname for the event
+- `hostname_column` - SQL result column containing the hostname
+- `tags` - Static event-only tags
+- `tag_columns` - SQL result columns to use as event-only tags
+
+Static `event.tags` are sent only with events. Use `event.tag_columns` for
+low-cardinality SQL result fields that should be available to Datadog event
+monitor queries and notification templates. Put high-cardinality details such as
+PID, exact runtime, client address, and query text in `event_text` instead of
+tags.
 
 ## Timestamp Support
 

--- a/pkg/anemometer/config/config.go
+++ b/pkg/anemometer/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -54,7 +55,26 @@ type MonitorConfig struct {
 	SleepDuration  int            `mapstructure:"sleep_duration"`
 	Metric         string         `mapstructure:"metric"`
 	MetricType     string         `mapstructure:"metric_type"`
+	EventConfig    EventConfig    `mapstructure:"event"`
 	SQL            string         `mapstructure:"sql"`
+}
+
+// EventConfig holds Datadog event-specific configuration for a monitor
+type EventConfig struct {
+	Enabled              bool     `mapstructure:"enabled"`
+	Title                string   `mapstructure:"title"`
+	TitleColumn          string   `mapstructure:"title_column"`
+	Text                 string   `mapstructure:"text"`
+	TextColumn           string   `mapstructure:"text_column"`
+	AlertType            string   `mapstructure:"alert_type"`
+	Priority             string   `mapstructure:"priority"`
+	SourceTypeName       string   `mapstructure:"source_type_name"`
+	AggregationKey       string   `mapstructure:"aggregation_key"`
+	AggregationKeyColumn string   `mapstructure:"aggregation_key_column"`
+	Hostname             string   `mapstructure:"hostname"`
+	HostnameColumn       string   `mapstructure:"hostname_column"`
+	Tags                 []string `mapstructure:"tags"`
+	TagColumns           []string `mapstructure:"tag_columns"`
 }
 
 // Read a config file and return a Config
@@ -84,7 +104,49 @@ func Read(configPath string) (*Config, error) {
 		} else {
 			config.Monitors[i].MetricType = strings.ToLower(config.Monitors[i].MetricType)
 		}
+
+		if config.Monitors[i].EventConfig.Enabled {
+			normalizeEventConfig(&config.Monitors[i].EventConfig)
+
+			if err := validateEventConfig(config.Monitors[i].EventConfig); err != nil {
+				return nil, fmt.Errorf("monitor %q: %w", config.Monitors[i].Name, err)
+			}
+		}
 	}
 
 	return config, nil
+}
+
+func normalizeEventConfig(eventConfig *EventConfig) {
+	if eventConfig.AlertType == "" {
+		eventConfig.AlertType = "info"
+	} else {
+		eventConfig.AlertType = strings.ToLower(eventConfig.AlertType)
+	}
+
+	if eventConfig.Priority == "" {
+		eventConfig.Priority = "normal"
+	} else {
+		eventConfig.Priority = strings.ToLower(eventConfig.Priority)
+	}
+
+	if eventConfig.SourceTypeName == "" {
+		eventConfig.SourceTypeName = "anemometer"
+	}
+}
+
+func validateEventConfig(eventConfig EventConfig) error {
+	switch eventConfig.AlertType {
+	case "info", "warning", "error", "success":
+	default:
+		return fmt.Errorf("unknown event alert type: %s", eventConfig.AlertType)
+	}
+
+	switch eventConfig.Priority {
+	case "normal", "low":
+	default:
+		return fmt.Errorf("unknown event priority: %s", eventConfig.Priority)
+	}
+
+	return nil
 }

--- a/pkg/anemometer/config/config_test.go
+++ b/pkg/anemometer/config/config_test.go
@@ -48,6 +48,139 @@ monitors:
 	assert.Equal(t, "gauge", cfg.Monitors[0].MetricType)
 }
 
+func TestEventConfig(t *testing.T) {
+	content := []byte(`
+---
+statsd:
+  address: 127.0.0.1:8125
+monitors:
+  - name: postgres-long-running-queries
+    database:
+      type: postgres
+      uri: postgresql://user:password@localhost:5432/database
+    sleep_duration: 1800
+    metric: postgres.long_running_query
+    metric_type: gauge
+    event:
+      enabled: true
+      title_column: event_title
+      text_column: event_text
+      alert_type: WARNING
+      priority: LOW
+      aggregation_key_column: event_aggregation_key
+      source_type_name: anemometer
+      tags:
+        - alert_type:long_running_query
+      tag_columns:
+        - database_name
+        - duration_bucket
+    sql: SELECT 1 AS metric
+`)
+	tmpfile, _ := ioutil.TempFile("", "config")
+
+	defer os.Remove(tmpfile.Name()) // clean up
+	defer tmpfile.Close()
+	tmpfile.Write(content)
+
+	cfg, err := Read(tmpfile.Name())
+	assert.NoError(t, err)
+
+	eventConfig := cfg.Monitors[0].EventConfig
+	assert.True(t, eventConfig.Enabled)
+	assert.Equal(t, "event_title", eventConfig.TitleColumn)
+	assert.Equal(t, "event_text", eventConfig.TextColumn)
+	assert.Equal(t, "warning", eventConfig.AlertType)
+	assert.Equal(t, "low", eventConfig.Priority)
+	assert.Equal(t, "event_aggregation_key", eventConfig.AggregationKeyColumn)
+	assert.Equal(t, "anemometer", eventConfig.SourceTypeName)
+	assert.Equal(t, []string{"alert_type:long_running_query"}, eventConfig.Tags)
+	assert.Equal(t, []string{"database_name", "duration_bucket"}, eventConfig.TagColumns)
+}
+
+func TestEventConfigDefaults(t *testing.T) {
+	content := []byte(`
+---
+statsd:
+  address: 127.0.0.1:8125
+monitors:
+  - name: postgres-long-running-queries
+    database:
+      type: postgres
+      uri: postgresql://user:password@localhost:5432/database
+    sleep_duration: 1800
+    metric: postgres.long_running_query
+    event:
+      enabled: true
+    sql: SELECT 1 AS metric
+`)
+	tmpfile, _ := ioutil.TempFile("", "config")
+
+	defer os.Remove(tmpfile.Name()) // clean up
+	defer tmpfile.Close()
+	tmpfile.Write(content)
+
+	cfg, err := Read(tmpfile.Name())
+	assert.NoError(t, err)
+
+	eventConfig := cfg.Monitors[0].EventConfig
+	assert.Equal(t, "info", eventConfig.AlertType)
+	assert.Equal(t, "normal", eventConfig.Priority)
+	assert.Equal(t, "anemometer", eventConfig.SourceTypeName)
+}
+
+func TestEventConfigValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		eventConfig string
+		expectedErr string
+	}{
+		{
+			name: "invalid_alert_type",
+			eventConfig: `
+      alert_type: warn
+`,
+			expectedErr: "unknown event alert type: warn",
+		},
+		{
+			name: "invalid_priority",
+			eventConfig: `
+      priority: high
+`,
+			expectedErr: "unknown event priority: high",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := []byte(`
+---
+statsd:
+  address: 127.0.0.1:8125
+monitors:
+  - name: postgres-long-running-queries
+    database:
+      type: postgres
+      uri: postgresql://user:password@localhost:5432/database
+    sleep_duration: 1800
+    metric: postgres.long_running_query
+    event:
+      enabled: true
+` + tt.eventConfig + `
+    sql: SELECT 1 AS metric
+`)
+			tmpfile, _ := ioutil.TempFile("", "config")
+
+			defer os.Remove(tmpfile.Name()) // clean up
+			defer tmpfile.Close()
+			tmpfile.Write(content)
+
+			_, err := Read(tmpfile.Name())
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
+}
+
 func TestMetricTypes(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/anemometer/monitor/monitor.go
+++ b/pkg/anemometer/monitor/monitor.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -22,11 +23,23 @@ type Monitor struct {
 	sleepDuration int
 	metric        string
 	metricType    string
-	sql           string
+	eventConfig   config.EventConfig
+	// Computed once per monitor because it is used for every returned row.
+	metricExcludedColumns map[string]struct{}
+	sql                   string
 }
 
 // New Monitor, pass in the MonitorConfig
 func New(statsdConfig config.StatsdConfig, monitorConfig config.MonitorConfig) (*Monitor, error) {
+	if monitorConfig.EventConfig.Enabled {
+		if _, err := getEventAlertType(monitorConfig.EventConfig.AlertType); err != nil {
+			return nil, err
+		}
+		if _, err := getEventPriority(monitorConfig.EventConfig.Priority); err != nil {
+			return nil, err
+		}
+	}
+
 	databaseConn, err := createDBConn(monitorConfig.DatabaseConfig.Type, monitorConfig.DatabaseConfig.URI)
 	if err != nil {
 		return nil, err
@@ -41,13 +54,15 @@ func New(statsdConfig config.StatsdConfig, monitorConfig config.MonitorConfig) (
 	}
 
 	monitor := Monitor{
-		databaseConn:  databaseConn,
-		statsdClient:  statsdClient,
-		name:          monitorConfig.Name,
-		sleepDuration: monitorConfig.SleepDuration,
-		metric:        monitorConfig.Metric,
-		metricType:    monitorConfig.MetricType,
-		sql:           monitorConfig.SQL,
+		databaseConn:          databaseConn,
+		statsdClient:          statsdClient,
+		name:                  monitorConfig.Name,
+		sleepDuration:         monitorConfig.SleepDuration,
+		metric:                monitorConfig.Metric,
+		metricType:            monitorConfig.MetricType,
+		eventConfig:           monitorConfig.EventConfig,
+		metricExcludedColumns: newMetricExcludedColumns(monitorConfig.EventConfig),
+		sql:                   monitorConfig.SQL,
 	}
 
 	return &monitor, nil
@@ -110,48 +125,129 @@ func (m *Monitor) sendMetric(rowMap map[string]interface{}, tags []string, debug
 	}
 }
 
+// sendEvent sends a Datadog event built from the configured event columns.
+func (m *Monitor) sendEvent(rowMap map[string]interface{}, tags []string, debug bool) error {
+	if !m.eventConfig.Enabled {
+		return nil
+	}
+
+	title, err := getEventField(rowMap, m.eventConfig.TitleColumn, m.eventConfig.Title, m.name, true)
+	if err != nil {
+		return err
+	}
+
+	text, err := getEventField(rowMap, m.eventConfig.TextColumn, m.eventConfig.Text, "", false)
+	if err != nil {
+		return err
+	}
+
+	alertType, err := getEventAlertType(m.eventConfig.AlertType)
+	if err != nil {
+		return err
+	}
+
+	priority, err := getEventPriority(m.eventConfig.Priority)
+	if err != nil {
+		return err
+	}
+
+	event := statsd.NewEvent(title, text)
+	event.AlertType = alertType
+	event.Priority = priority
+	event.SourceTypeName = m.eventConfig.SourceTypeName
+	event.Tags = tags
+
+	aggregationKey, err := getEventField(rowMap, m.eventConfig.AggregationKeyColumn, m.eventConfig.AggregationKey, "", false)
+	if err != nil {
+		return err
+	}
+	event.AggregationKey = aggregationKey
+
+	hostname, err := getEventField(rowMap, m.eventConfig.HostnameColumn, m.eventConfig.Hostname, "", false)
+	if err != nil {
+		return err
+	}
+	event.Hostname = hostname
+
+	if debug {
+		log.Printf("DEBUG: [%s] Publishing event - Title: %s, AlertType: %s, Priority: %s, Tags: %v",
+			m.name, event.Title, event.AlertType, event.Priority, event.Tags)
+	}
+
+	return m.statsdClient.Event(event)
+}
+
 // Start the Monitor
 func (m *Monitor) Start(debug bool) {
 	for {
 		log.Printf("INFO: [%s] Sleeping for %d seconds", m.name, m.sleepDuration)
 		time.Sleep(time.Duration(m.sleepDuration) * time.Second)
 
-		// Execute our query
-		rows, err := m.databaseConn.Query(m.sql)
+		m.runOnce(debug)
+	}
+}
+
+func (m *Monitor) runOnce(debug bool) {
+	rows, err := m.databaseConn.Query(m.sql)
+	if err != nil {
+		log.Printf("ERROR: [%s] %v", m.name, err)
+		sendErrorMetric(m.statsdClient, m.name)
+		return
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("ERROR: [%s] %v", m.name, err)
+			sendErrorMetric(m.statsdClient, m.name)
+		}
+	}()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		log.Printf("ERROR: [%s] %v", m.name, err)
+		sendErrorMetric(m.statsdClient, m.name)
+		return
+	}
+
+	// Iterate on the resulting rows
+	for rows.Next() {
+		// Convert our result row into a map
+		rowMap, err := rowsToMap(cols, rows)
 		if err != nil {
 			log.Printf("ERROR: [%s] %v", m.name, err)
 			sendErrorMetric(m.statsdClient, m.name)
 			continue
 		}
 
-		cols, err := rows.Columns()
-		if err != nil {
-			log.Printf("ERROR: [%s] %v", m.name, err)
-			sendErrorMetric(m.statsdClient, m.name)
-			continue
-		}
+		m.processRow(rowMap, debug)
+	}
 
-		// Iterate on the resulting rows
-		for rows.Next() {
+	if err := rows.Err(); err != nil {
+		log.Printf("ERROR: [%s] %v", m.name, err)
+		sendErrorMetric(m.statsdClient, m.name)
+	}
+}
 
-			// Convert our result row into a map
-			rowMap, err := rowsToMap(cols, rows)
-			if err != nil {
-				log.Printf("ERROR: [%s] %v", m.name, err)
-				sendErrorMetric(m.statsdClient, m.name)
-				continue
-			}
+func (m *Monitor) processRow(rowMap map[string]interface{}, debug bool) {
+	// Send the metric to Datadog using the configured metric type.
+	if err := m.sendMetric(rowMap, m.getMetricTags(rowMap), debug); err != nil {
+		log.Printf("ERROR: [%s] %v", m.name, err)
+		sendErrorMetric(m.statsdClient, m.name)
+	}
 
-			// Aggregate all the tags from the query
-			tags := getTags(rowMap)
+	if !m.eventConfig.Enabled {
+		return
+	}
 
-			// Send the metric to Datadog using the configured metric type
-			if err = m.sendMetric(rowMap, tags, debug); err != nil {
-				log.Printf("ERROR: [%s] %v", m.name, err)
-				sendErrorMetric(m.statsdClient, m.name)
-			}
-		}
+	eventTags, err := m.getEventTags(rowMap)
+	if err != nil {
+		log.Printf("ERROR: [%s] %v", m.name, err)
+		sendErrorMetric(m.statsdClient, m.name)
+		return
+	}
 
+	if err = m.sendEvent(rowMap, eventTags, debug); err != nil {
+		log.Printf("ERROR: [%s] %v", m.name, err)
+		sendErrorMetric(m.statsdClient, m.name)
 	}
 }
 
@@ -196,11 +292,81 @@ func rowsToMap(cols []string, rows *sql.Rows) (map[string]interface{}, error) {
 // Function to aggregate tag columns
 // Assume that any column not named "metric" or "timestamp" is a tag
 func getTags(results map[string]interface{}) []string {
+	return getTagsExcluding(results, reservedMetricColumns())
+}
+
+func (m *Monitor) getMetricTags(results map[string]interface{}) []string {
+	excludedColumns := m.metricExcludedColumns
+	if excludedColumns == nil {
+		excludedColumns = newMetricExcludedColumns(m.eventConfig)
+	}
+
+	return getTagsExcluding(results, excludedColumns)
+}
+
+func (m *Monitor) getEventTags(results map[string]interface{}) ([]string, error) {
+	tags := make([]string, 0, len(m.eventConfig.Tags)+len(m.eventConfig.TagColumns))
+	tags = append(tags, m.eventConfig.Tags...)
+
+	for _, column := range m.eventConfig.TagColumns {
+		value, ok := getColumnString(results, column)
+		if !ok {
+			return nil, fmt.Errorf("event tag column not found: %s", column)
+		}
+
+		tags = append(tags, fmt.Sprintf("%v:%v", column, value))
+	}
+
+	return tags, nil
+}
+
+func reservedMetricColumns() map[string]struct{} {
+	return map[string]struct{}{
+		"metric":    {},
+		"timestamp": {},
+	}
+}
+
+func newMetricExcludedColumns(eventConfig config.EventConfig) map[string]struct{} {
+	excludedColumns := reservedMetricColumns()
+
+	if eventConfig.Enabled {
+		for _, name := range eventMetricExcludedColumns(eventConfig) {
+			excludedColumns[name] = struct{}{}
+		}
+	}
+
+	return excludedColumns
+}
+
+func eventMetricExcludedColumns(eventConfig config.EventConfig) []string {
+	columns := []string{
+		"event_title",
+		"event_text",
+		"event_aggregation_key",
+		"event_hostname",
+	}
+
+	for _, column := range []string{
+		eventConfig.TitleColumn,
+		eventConfig.TextColumn,
+		eventConfig.AggregationKeyColumn,
+		eventConfig.HostnameColumn,
+	} {
+		if column != "" {
+			columns = append(columns, column)
+		}
+	}
+
+	return columns
+}
+
+func getTagsExcluding(results map[string]interface{}, excludedColumns map[string]struct{}) []string {
 	var tags []string
 
 	for name, value := range results {
 		// Ignore the metric and timestamp columns, we only care about tags here
-		if name == "metric" || name == "timestamp" {
+		if _, ok := excludedColumns[name]; ok {
 			continue
 		}
 
@@ -209,6 +375,81 @@ func getTags(results map[string]interface{}) []string {
 	}
 
 	return tags
+}
+
+func getEventField(results map[string]interface{}, column string, fallback string, defaultValue string, required bool) (string, error) {
+	if column != "" {
+		value, ok := getColumnString(results, column)
+		if !ok {
+			return "", fmt.Errorf("event column not found: %s", column)
+		}
+
+		if value != "" {
+			return value, nil
+		}
+	}
+
+	if fallback != "" {
+		return fallback, nil
+	}
+
+	if defaultValue != "" {
+		return defaultValue, nil
+	}
+
+	if required {
+		return "", fmt.Errorf("event title is required")
+	}
+
+	return "", nil
+}
+
+func getColumnString(results map[string]interface{}, column string) (string, bool) {
+	value, ok := results[column]
+	if !ok {
+		return "", false
+	}
+
+	if value == nil {
+		return "", true
+	}
+
+	switch v := value.(type) {
+	case string:
+		return v, true
+	case []byte:
+		return string(v), true
+	case time.Time:
+		return v.Format(time.RFC3339), true
+	default:
+		return fmt.Sprintf("%v", v), true
+	}
+}
+
+func getEventAlertType(alertType string) (statsd.EventAlertType, error) {
+	switch strings.ToLower(alertType) {
+	case "", "info":
+		return statsd.Info, nil
+	case "error":
+		return statsd.Error, nil
+	case "warning":
+		return statsd.Warning, nil
+	case "success":
+		return statsd.Success, nil
+	default:
+		return "", fmt.Errorf("unknown event alert type: %s", alertType)
+	}
+}
+
+func getEventPriority(priority string) (statsd.EventPriority, error) {
+	switch strings.ToLower(priority) {
+	case "", "normal":
+		return statsd.Normal, nil
+	case "low":
+		return statsd.Low, nil
+	default:
+		return "", fmt.Errorf("unknown event priority: %s", priority)
+	}
 }
 
 // Function to pull the 'metric' column's value, convert, and return it as float64

--- a/pkg/anemometer/monitor/monitor_test.go
+++ b/pkg/anemometer/monitor/monitor_test.go
@@ -3,9 +3,11 @@ package monitor
 import (
 	"database/sql"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	mock_statsd "github.com/DataDog/datadog-go/v5/statsd/mocks"
 	"github.com/golang/mock/gomock"
 	_ "github.com/mattn/go-sqlite3"
@@ -135,22 +137,153 @@ func TestMonitorIntegration(t *testing.T) {
 				sql:           tc.sqlQuery,
 			}
 
-			// Execute query and send metric (simulates one monitor cycle)
-			rows, err := monitor.databaseConn.Query(monitor.sql)
-			assert.NoError(t, err)
-			defer rows.Close()
+			monitor.runOnce(false)
+		})
+	}
+}
 
-			cols, err := rows.Columns()
-			assert.NoError(t, err)
+func TestMonitorIntegrationWithEvent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-			for rows.Next() {
-				rowMap, err := rowsToMap(cols, rows)
-				assert.NoError(t, err)
+	mockStatsD := mock_statsd.NewMockClientInterface(ctrl)
+	mockStatsD.EXPECT().GaugeWithTimestamp(
+		"postgres.long_running_query",
+		1.0,
+		stringSliceMatcher{expected: []string{"database_name:analytics", "duration_bucket:2h_plus"}},
+		float64(1),
+		gomock.Any(),
+	).Return(nil)
+	mockStatsD.EXPECT().Event(statsdEventMatcher{
+		expected: statsd.Event{
+			Title:          "Long running Postgres query",
+			Text:           "Database: analytics\nUser: reporting_user\nPID: 41273",
+			AggregationKey: "postgres-long-running-query:analytics:41273",
+			Priority:       statsd.Normal,
+			SourceTypeName: "anemometer",
+			AlertType:      statsd.Warning,
+			Tags: []string{
+				"alert_type:long_running_query",
+				"database_name:analytics",
+				"duration_bucket:2h_plus",
+			},
+		},
+	}).Return(nil)
 
-				tags := getTags(rowMap)
-				err = monitor.sendMetric(rowMap, tags, false)
-				assert.NoError(t, err)
-			}
+	databaseConn, err := createDBConn("sqlite3", ":memory:")
+	assert.NoError(t, err)
+	defer databaseConn.Close()
+
+	monitor := &Monitor{
+		databaseConn:  databaseConn,
+		statsdClient:  mockStatsD,
+		name:          "postgres-long-running-queries",
+		sleepDuration: 100,
+		metric:        "postgres.long_running_query",
+		metricType:    "gauge",
+		eventConfig: config.EventConfig{
+			Enabled:              true,
+			TitleColumn:          "event_title",
+			TextColumn:           "event_text",
+			AlertType:            "warning",
+			Priority:             "normal",
+			SourceTypeName:       "anemometer",
+			AggregationKeyColumn: "event_aggregation_key",
+			Tags:                 []string{"alert_type:long_running_query"},
+			TagColumns:           []string{"database_name", "duration_bucket"},
+		},
+		sql: `
+			SELECT 1 AS metric,
+			       'analytics' AS database_name,
+			       '2h_plus' AS duration_bucket,
+			       'Long running Postgres query' AS event_title,
+			       'Database: analytics
+User: reporting_user
+PID: 41273' AS event_text,
+			       'postgres-long-running-query:analytics:41273' AS event_aggregation_key
+		`,
+	}
+
+	monitor.runOnce(false)
+}
+
+func TestProcessRowMetricFailureDoesNotSkipEvent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStatsD := mock_statsd.NewMockClientInterface(ctrl)
+	mockStatsD.EXPECT().GaugeWithTimestamp("postgres.long_running_query", 1.0, []string{"database_name:analytics"}, float64(1), gomock.Any()).Return(fmt.Errorf("metric send failed"))
+	mockStatsD.EXPECT().Gauge("anemometer.error", 1.0, []string{"name:postgres-long-running-queries"}, float64(1)).Return(nil)
+	mockStatsD.EXPECT().Event(statsdEventMatcher{
+		expected: statsd.Event{
+			Title:          "Long running Postgres query",
+			Text:           "Database: analytics",
+			AggregationKey: "postgres-long-running-query:analytics:41273",
+			Priority:       statsd.Normal,
+			SourceTypeName: "anemometer",
+			AlertType:      statsd.Warning,
+			Tags:           []string{"database_name:analytics"},
+		},
+	}).Return(nil)
+
+	monitor := &Monitor{
+		statsdClient: mockStatsD,
+		name:         "postgres-long-running-queries",
+		metric:       "postgres.long_running_query",
+		metricType:   "gauge",
+		eventConfig: config.EventConfig{
+			Enabled:              true,
+			Title:                "Long running Postgres query",
+			TextColumn:           "event_text",
+			AlertType:            "warning",
+			Priority:             "normal",
+			SourceTypeName:       "anemometer",
+			AggregationKeyColumn: "event_aggregation_key",
+			TagColumns:           []string{"database_name"},
+		},
+	}
+
+	monitor.processRow(map[string]interface{}{
+		"metric":                1,
+		"database_name":         "analytics",
+		"event_text":            "Database: analytics",
+		"event_aggregation_key": "postgres-long-running-query:analytics:41273",
+	}, false)
+}
+
+func TestMonitorNewRejectsInvalidEventConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		eventConfig config.EventConfig
+		expectedErr string
+	}{
+		{
+			name: "invalid_alert_type",
+			eventConfig: config.EventConfig{
+				Enabled:   true,
+				AlertType: "user_update",
+			},
+			expectedErr: "unknown event alert type: user_update",
+		},
+		{
+			name: "invalid_priority",
+			eventConfig: config.EventConfig{
+				Enabled:  true,
+				Priority: "high",
+			},
+			expectedErr: "unknown event priority: high",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			monitor, err := New(config.StatsdConfig{}, config.MonitorConfig{
+				EventConfig: tt.eventConfig,
+			})
+
+			assert.Nil(t, monitor)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedErr)
 		})
 	}
 }
@@ -284,6 +417,37 @@ func TestGetTags(t *testing.T) {
 			assert.ElementsMatch(t, tt.expected, result)
 		})
 	}
+}
+
+func TestGetMetricTagsWithEventConfig(t *testing.T) {
+	rowMap := map[string]interface{}{
+		"metric":                1,
+		"timestamp":             "2023-12-25T10:30:00Z",
+		"event_title":           "Long running Postgres query",
+		"event_text":            "PID: 41273",
+		"event_aggregation_key": "postgres-long-running-query:analytics:41273",
+		"database_name":         "analytics",
+		"duration_bucket":       "2h_plus",
+		"pid":                   41273,
+		"user_name":             "reporting_user",
+	}
+
+	monitor := &Monitor{
+		eventConfig: config.EventConfig{
+			Enabled:              true,
+			TitleColumn:          "event_title",
+			TextColumn:           "event_text",
+			AggregationKeyColumn: "event_aggregation_key",
+			TagColumns:           []string{"database_name", "duration_bucket"},
+		},
+	}
+
+	assert.ElementsMatch(t, []string{
+		"database_name:analytics",
+		"duration_bucket:2h_plus",
+		"pid:41273",
+		"user_name:reporting_user",
+	}, monitor.getMetricTags(rowMap))
 }
 
 func TestGetTimestamp(t *testing.T) {
@@ -530,4 +694,109 @@ func TestMetricTypeHandling(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEventTypeHandling(t *testing.T) {
+	tests := []struct {
+		name      string
+		alertType string
+		priority  string
+		expectErr bool
+	}{
+		{name: "defaults", alertType: "", priority: "", expectErr: false},
+		{name: "warning_normal", alertType: "warning", priority: "normal", expectErr: false},
+		{name: "success_low", alertType: "success", priority: "low", expectErr: false},
+		{name: "unknown_alert_type", alertType: "user_update", priority: "normal", expectErr: true},
+		{name: "unknown_priority", alertType: "warning", priority: "high", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockStatsD := mock_statsd.NewMockClientInterface(ctrl)
+			if !tt.expectErr {
+				mockStatsD.EXPECT().Event(gomock.Any()).Return(nil)
+			}
+
+			monitor := &Monitor{
+				name:         "test-event-monitor",
+				statsdClient: mockStatsD,
+				eventConfig: config.EventConfig{
+					Enabled:    true,
+					Title:      "Test event",
+					Text:       "Test event body",
+					AlertType:  tt.alertType,
+					Priority:   tt.priority,
+					TagColumns: []string{},
+				},
+			}
+
+			err := monitor.sendEvent(map[string]interface{}{}, []string{}, false)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+type statsdEventMatcher struct {
+	expected statsd.Event
+}
+
+func (m statsdEventMatcher) Matches(value interface{}) bool {
+	event, ok := value.(*statsd.Event)
+	if !ok {
+		return false
+	}
+
+	return event.Title == m.expected.Title &&
+		event.Text == m.expected.Text &&
+		event.Timestamp.Equal(m.expected.Timestamp) &&
+		event.Hostname == m.expected.Hostname &&
+		event.AggregationKey == m.expected.AggregationKey &&
+		event.Priority == m.expected.Priority &&
+		event.SourceTypeName == m.expected.SourceTypeName &&
+		event.AlertType == m.expected.AlertType &&
+		reflect.DeepEqual(event.Tags, m.expected.Tags)
+}
+
+func (m statsdEventMatcher) String() string {
+	return fmt.Sprintf("matches statsd event %+v", m.expected)
+}
+
+type stringSliceMatcher struct {
+	expected []string
+}
+
+func (m stringSliceMatcher) Matches(value interface{}) bool {
+	actual, ok := value.([]string)
+	if !ok {
+		return false
+	}
+
+	if len(actual) != len(m.expected) {
+		return false
+	}
+
+	counts := make(map[string]int, len(m.expected))
+	for _, value := range m.expected {
+		counts[value]++
+	}
+	for _, value := range actual {
+		counts[value]--
+		if counts[value] < 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (m stringSliceMatcher) String() string {
+	return fmt.Sprintf("matches string slice %v", m.expected)
 }


### PR DESCRIPTION
[AUD-6993]
---

These changes introduce an optional event configuration to monitors. The monitor will still send a metric but now also includes the option to send an event with "rich context" as well as the metric. I think another iteration of this could split events out to support event-only configurations.

- add optional per-monitor event configuration parsing and defaults
- emit one Datadog event per returned SQL row alongside the configured metric
- exclude event payload columns from metric tags
- validate event alert type and priority during config load/startup
- close query rows after each monitor cycle
- document event monitor configuration and additive metric behavior

[AUD-6993]: https://simplifi.atlassian.net/browse/AUD-6993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ