### PR TITLE
Bump go toolchain: 1.24 -> 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/simplifi/anemometer
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.2
+toolchain go1.25.11
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.8.1


### PR DESCRIPTION
Raise the module Go floor from 1.24.0 to 1.25.0 so newer OpenTelemetry dependency updates can be accepted.

Set the preferred toolchain to go1.25.11, the latest Go 1.25 patch release, while keeping the minimum supported version at 1.25.0.

Verified with:
- go mod tidy
- make test

re: [Will be required for otem 1.42+](https://github.com/open-telemetry/opentelemetry-go/blob/main/CHANGELOG.md#1410063001700015-2026-03-02)